### PR TITLE
rename macros to avoid collisions

### DIFF
--- a/include/json/autolink.h
+++ b/include/json/autolink.h
@@ -3,22 +3,22 @@
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
 
-#ifndef JSON_AUTOLINK_H_INCLUDED
-# define JSON_AUTOLINK_H_INCLUDED
+#ifndef JSONCPP_AUTOLINK_H_INCLUDED
+# define JSONCPP_AUTOLINK_H_INCLUDED
 
 # include "config.h"
 
-# ifdef JSON_IN_CPPTL
+# ifdef JSONCPP_IN_CPPTL
 #  include <cpptl/cpptl_autolink.h>
 # endif
 
-# if !defined(JSON_NO_AUTOLINK)  &&  !defined(JSON_DLL_BUILD)  &&  !defined(JSON_IN_CPPTL)
+# if !defined(JSONCPP_NO_AUTOLINK)  &&  !defined(JSONCPP_DLL_BUILD)  &&  !defined(JSONCPP_IN_CPPTL)
 #  define CPPTL_AUTOLINK_NAME "json"
 #  undef CPPTL_AUTOLINK_DLL
-#  ifdef JSON_DLL
+#  ifdef JSONCPP_DLL
 #   define CPPTL_AUTOLINK_DLL
 #  endif
 #  include "autolink.h"
 # endif
 
-#endif // JSON_AUTOLINK_H_INCLUDED
+#endif // JSONCPP_AUTOLINK_H_INCLUDED

--- a/include/json/config.h
+++ b/include/json/config.h
@@ -3,65 +3,65 @@
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
 
-#ifndef JSON_CONFIG_H_INCLUDED
-# define JSON_CONFIG_H_INCLUDED
+#ifndef JSONCPP_CONFIG_H_INCLUDED
+# define JSONCPP_CONFIG_H_INCLUDED
 
 /// If defined, indicates that json library is embedded in CppTL library.
-//# define JSON_IN_CPPTL 1
+//# define JSONCPP_IN_CPPTL 1
 
 /// If defined, indicates that json may leverage CppTL library
-//#  define JSON_USE_CPPTL 1
+//#  define JSONCPP_USE_CPPTL 1
 /// If defined, indicates that cpptl vector based map should be used instead of std::map
 /// as Value container.
-//#  define JSON_USE_CPPTL_SMALLMAP 1
+//#  define JSONCPP_USE_CPPTL_SMALLMAP 1
 /// If defined, indicates that Json specific container should be used
 /// (hash table & simple deque container with customizable allocator).
 /// THIS FEATURE IS STILL EXPERIMENTAL! There is know bugs: See #3177332
-//#  define JSON_VALUE_USE_INTERNAL_MAP 1
+//#  define JSONCPP_VALUE_USE_INTERNAL_MAP 1
 /// Force usage of standard new/malloc based allocator instead of memory pool based allocator.
 /// The memory pools allocator used optimization (initializing Value and ValueInternalLink
 /// as if it was a POD) that may cause some validation tool to report errors.
-/// Only has effects if JSON_VALUE_USE_INTERNAL_MAP is defined.
-//#  define JSON_USE_SIMPLE_INTERNAL_ALLOCATOR 1
+/// Only has effects if JSONCPP_VALUE_USE_INTERNAL_MAP is defined.
+//#  define JSONCPP_USE_SIMPLE_INTERNAL_ALLOCATOR 1
 
 /// If defined, indicates that Json use exception to report invalid type manipulation
 /// instead of C assert macro.
-# define JSON_USE_EXCEPTION 1
+# define JSONCPP_USE_EXCEPTION 1
 
 /// If defined, indicates that the source file is amalgated
 /// to prevent private header inclusion.
 /// Remarks: it is automatically defined in the generated amalgated header.
-// #define JSON_IS_AMALGAMATION
+// #define JSONCPP_IS_AMALGAMATION
 
 /// If defined, all asserts will be enabled. Else, they will have no effect
-/// Remarks: defining this macro enables the functionality of: JSON_ASSERT_UNREACHABLE, JSON_ASSERT, JSON_FAIL_MESSAGE, and JSON_ASSERT_MESSAGE
-//# define JSON_ENABLE_ASSERTS 1
+/// Remarks: defining this macro enables the functionality of: JSONCPP_ASSERT_UNREACHABLE, JSONCPP_ASSERT, JSONCPP_FAIL_MESSAGE, and JSONCPP_ASSERT_MESSAGE
+//# define JSONCPP_ENABLE_ASSERTS 1
 
-# ifdef JSON_IN_CPPTL
+# ifdef JSONCPP_IN_CPPTL
 #  include <cpptl/config.h>
-#  ifndef JSON_USE_CPPTL
-#   define JSON_USE_CPPTL 1
+#  ifndef JSONCPP_USE_CPPTL
+#   define JSONCPP_USE_CPPTL 1
 #  endif
 # endif
 
-# ifdef JSON_IN_CPPTL
-#  define JSON_API CPPTL_API
-# elif defined(JSON_DLL_BUILD)
-#  define JSON_API __declspec(dllexport)
-# elif defined(JSON_DLL)
-#  define JSON_API __declspec(dllimport)
+# ifdef JSONCPP_IN_CPPTL
+#  define JSONCPP_API CPPTL_API
+# elif defined(JSONCPP_DLL_BUILD)
+#  define JSONCPP_API __declspec(dllexport)
+# elif defined(JSONCPP_DLL)
+#  define JSONCPP_API __declspec(dllimport)
 # else
-#  define JSON_API
+#  define JSONCPP_API
 # endif
 
-// If JSON_NO_INT64 is defined, then Json only support C++ "int" type for integer
+// If JSONCPP_NO_INT64 is defined, then Json only support C++ "int" type for integer
 // Storages, and 64 bits integer support is disabled.
-// #define JSON_NO_INT64 1
+// #define JSONCPP_NO_INT64 1
 
 #if defined(_MSC_VER)  &&  _MSC_VER <= 1200 // MSVC 6
 // Microsoft Visual Studio 6 only support conversion from __int64 to double
 // (no conversion from unsigned __int64).
-#define JSON_USE_INT64_DOUBLE_CONVERSION 1
+#define JSONCPP_USE_INT64_DOUBLE_CONVERSION 1
 #endif // if defined(_MSC_VER)  &&  _MSC_VER < 1200 // MSVC 6
 
 #if defined(_MSC_VER)  &&  _MSC_VER >= 1500 // MSVC 2008
@@ -76,11 +76,11 @@
 namespace Json {
    typedef int Int;
    typedef unsigned int UInt;
-# if defined(JSON_NO_INT64)
+# if defined(JSONCPP_NO_INT64)
    typedef int LargestInt;
    typedef unsigned int LargestUInt;
-#  undef JSON_HAS_INT64
-# else // if defined(JSON_NO_INT64)
+#  undef JSONCPP_HAS_INT64
+# else // if defined(JSONCPP_NO_INT64)
    // For Microsoft Visual use specific types as long long is not supported
 #  if defined(_MSC_VER) // Microsoft Visual Studio
    typedef __int64 Int64;
@@ -91,9 +91,9 @@ namespace Json {
 #  endif // if defined(_MSC_VER)
    typedef Int64 LargestInt;
    typedef UInt64 LargestUInt;
-#  define JSON_HAS_INT64
-# endif // if defined(JSON_NO_INT64)
+#  define JSONCPP_HAS_INT64
+# endif // if defined(JSONCPP_NO_INT64)
 } // end namespace Json
 
 
-#endif // JSON_CONFIG_H_INCLUDED
+#endif // JSONCPP_CONFIG_H_INCLUDED

--- a/include/json/features.h
+++ b/include/json/features.h
@@ -3,12 +3,12 @@
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
 
-#ifndef CPPTL_JSON_FEATURES_H_INCLUDED
-# define CPPTL_JSON_FEATURES_H_INCLUDED
+#ifndef CPPTL_JSONCPP_FEATURES_H_INCLUDED
+# define CPPTL_JSONCPP_FEATURES_H_INCLUDED
 
-#if !defined(JSON_IS_AMALGAMATION)
+#if !defined(JSONCPP_IS_AMALGAMATION)
 # include "forwards.h"
-#endif // if !defined(JSON_IS_AMALGAMATION)
+#endif // if !defined(JSONCPP_IS_AMALGAMATION)
 
 namespace Json {
 
@@ -16,7 +16,7 @@ namespace Json {
     * This configuration object can be used to force the Reader or Writer
     * to behave in a standard conforming way.
     */
-   class JSON_API Features
+   class JSONCPP_API Features
    {
    public:
       /** \brief A configuration that allows all features and assumes all strings are UTF-8.
@@ -46,4 +46,4 @@ namespace Json {
 
 } // namespace Json
 
-#endif // CPPTL_JSON_FEATURES_H_INCLUDED
+#endif // CPPTL_JSONCPP_FEATURES_H_INCLUDED

--- a/include/json/forwards.h
+++ b/include/json/forwards.h
@@ -3,12 +3,12 @@
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
 
-#ifndef JSON_FORWARDS_H_INCLUDED
-# define JSON_FORWARDS_H_INCLUDED
+#ifndef JSONCPP_FORWARDS_H_INCLUDED
+# define JSONCPP_FORWARDS_H_INCLUDED
 
-#if !defined(JSON_IS_AMALGAMATION)
+#if !defined(JSONCPP_IS_AMALGAMATION)
 # include "config.h"
-#endif // if !defined(JSON_IS_AMALGAMATION)
+#endif // if !defined(JSONCPP_IS_AMALGAMATION)
 
 namespace Json {
 
@@ -31,14 +31,14 @@ namespace Json {
    class ValueIteratorBase;
    class ValueIterator;
    class ValueConstIterator;
-#ifdef JSON_VALUE_USE_INTERNAL_MAP
+#ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    class ValueMapAllocator;
    class ValueInternalLink;
    class ValueInternalArray;
    class ValueInternalMap;
-#endif // #ifdef JSON_VALUE_USE_INTERNAL_MAP
+#endif // #ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
 
 } // namespace Json
 
 
-#endif // JSON_FORWARDS_H_INCLUDED
+#endif // JSONCPP_FORWARDS_H_INCLUDED

--- a/include/json/json.h
+++ b/include/json/json.h
@@ -3,8 +3,8 @@
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
 
-#ifndef JSON_JSON_H_INCLUDED
-# define JSON_JSON_H_INCLUDED
+#ifndef JSONCPP_JSON_H_INCLUDED
+# define JSONCPP_JSON_H_INCLUDED
 
 # include "autolink.h"
 # include "value.h"
@@ -12,4 +12,4 @@
 # include "writer.h"
 # include "features.h"
 
-#endif // JSON_JSON_H_INCLUDED
+#endif // JSONCPP_JSON_H_INCLUDED

--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -3,13 +3,13 @@
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
 
-#ifndef CPPTL_JSON_READER_H_INCLUDED
-# define CPPTL_JSON_READER_H_INCLUDED
+#ifndef CPPTL_JSONCPP_READER_H_INCLUDED
+# define CPPTL_JSONCPP_READER_H_INCLUDED
 
-#if !defined(JSON_IS_AMALGAMATION)
+#if !defined(JSONCPP_IS_AMALGAMATION)
 # include "features.h"
 # include "value.h"
-#endif // if !defined(JSON_IS_AMALGAMATION)
+#endif // if !defined(JSONCPP_IS_AMALGAMATION)
 # include <deque>
 # include <stack>
 # include <string>
@@ -20,7 +20,7 @@ namespace Json {
    /** \brief Unserialize a <a HREF="http://www.json.org">JSON</a> document into a Value.
     *
     */
-   class JSON_API Reader
+   class JSONCPP_API Reader
    {
    public:
       typedef char Char;
@@ -211,4 +211,4 @@ namespace Json {
 
 } // namespace Json
 
-#endif // CPPTL_JSON_READER_H_INCLUDED
+#endif // CPPTL_JSONCPP_READER_H_INCLUDED

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -3,34 +3,34 @@
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
 
-#ifndef CPPTL_JSON_H_INCLUDED
-# define CPPTL_JSON_H_INCLUDED
+#ifndef CPPTL_JSONCPP_H_INCLUDED
+# define CPPTL_JSONCPP_H_INCLUDED
 
-#if !defined(JSON_IS_AMALGAMATION)
+#if !defined(JSONCPP_IS_AMALGAMATION)
 # include "forwards.h"
-#endif // if !defined(JSON_IS_AMALGAMATION)
+#endif // if !defined(JSONCPP_IS_AMALGAMATION)
 # include <string>
 # include <vector>
 
-# ifndef JSON_USE_CPPTL_SMALLMAP
+# ifndef JSONCPP_USE_CPPTL_SMALLMAP
 #  include <map>
 # else
 #  include <cpptl/smallmap.h>
 # endif
-# ifdef JSON_USE_CPPTL
+# ifdef JSONCPP_USE_CPPTL
 #  include <cpptl/forwards.h>
 # endif
 
-#ifdef JSON_ENABLE_ASSERTS
-#define JSON_ASSERT_UNREACHABLE assert( false )
-#define JSON_ASSERT( condition ) assert( condition );  // @todo <= change this into an exception throw
-#define JSON_FAIL_MESSAGE( message ) throw std::runtime_error( message );
-#define JSON_ASSERT_MESSAGE( condition, message ) if (!( condition )) JSON_FAIL_MESSAGE( message )
+#ifdef JSONCPP_ENABLE_ASSERTS
+#define JSONCPP_ASSERT_UNREACHABLE assert( false )
+#define JSONCPP_ASSERT( condition ) assert( condition );  // @todo <= change this into an exception throw
+#define JSONCPP_FAIL_MESSAGE( message ) throw std::runtime_error( message );
+#define JSONCPP_ASSERT_MESSAGE( condition, message ) if (!( condition )) JSONCPP_FAIL_MESSAGE( message )
 #else
-#define JSON_ASSERT_UNREACHABLE break
-#define JSON_ASSERT( condition ) static_cast<void>(0)
-#define JSON_FAIL_MESSAGE( message ) static_cast<void>(0)
-#define JSON_ASSERT_MESSAGE( condition, message ) static_cast<void>(0)
+#define JSONCPP_ASSERT_UNREACHABLE break
+#define JSONCPP_ASSERT( condition ) static_cast<void>(0)
+#define JSONCPP_FAIL_MESSAGE( message ) static_cast<void>(0)
+#define JSONCPP_ASSERT_MESSAGE( condition, message ) static_cast<void>(0)
 #endif
 
 /** \brief JSON (JavaScript Object Notation).
@@ -59,7 +59,7 @@ namespace Json {
       numberOfCommentPlacement
    };
 
-//# ifdef JSON_USE_CPPTL
+//# ifdef JSONCPP_USE_CPPTL
 //   typedef CppTL::AnyEnumerator<const char *> EnumMemberNames;
 //   typedef CppTL::AnyEnumerator<const Value &> EnumValues;
 //# endif
@@ -78,7 +78,7 @@ namespace Json {
     * object[code] = 1234;
     * \endcode
     */
-   class JSON_API StaticString
+   class JSONCPP_API StaticString
    {
    public:
       explicit StaticString( const char *czstring )
@@ -127,10 +127,10 @@ namespace Json {
     * It is possible to iterate over the list of a #objectValue values using 
     * the getMemberNames() method.
     */
-   class JSON_API Value 
+   class JSONCPP_API Value 
    {
       friend class ValueIteratorBase;
-# ifdef JSON_VALUE_USE_INTERNAL_MAP
+# ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
       friend class ValueInternalLink;
       friend class ValueInternalMap;
 # endif
@@ -140,10 +140,10 @@ namespace Json {
       typedef ValueConstIterator const_iterator;
       typedef Json::UInt UInt;
       typedef Json::Int Int;
-# if defined(JSON_HAS_INT64)
+# if defined(JSONCPP_HAS_INT64)
       typedef Json::UInt64 UInt64;
       typedef Json::Int64 Int64;
-#endif // defined(JSON_HAS_INT64)
+#endif // defined(JSONCPP_HAS_INT64)
       typedef Json::LargestInt LargestInt;
       typedef Json::LargestUInt LargestUInt;
       typedef Json::ArrayIndex ArrayIndex;
@@ -172,7 +172,7 @@ namespace Json {
 
    private:
 #ifndef JSONCPP_DOC_EXCLUDE_IMPLEMENTATION
-# ifndef JSON_VALUE_USE_INTERNAL_MAP
+# ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
       class CZString 
       {
       public:
@@ -199,12 +199,12 @@ namespace Json {
       };
 
    public:
-#  ifndef JSON_USE_CPPTL_SMALLMAP
+#  ifndef JSONCPP_USE_CPPTL_SMALLMAP
       typedef std::map<CZString, Value> ObjectValues;
 #  else
       typedef CppTL::SmallMap<CZString, Value> ObjectValues;
-#  endif // ifndef JSON_USE_CPPTL_SMALLMAP
-# endif // ifndef JSON_VALUE_USE_INTERNAL_MAP
+#  endif // ifndef JSONCPP_USE_CPPTL_SMALLMAP
+# endif // ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
 #endif // ifndef JSONCPP_DOC_EXCLUDE_IMPLEMENTATION
 
    public:
@@ -226,10 +226,10 @@ namespace Json {
       Value( ValueType type = nullValue );
       Value( Int value );
       Value( UInt value );
-#if defined(JSON_HAS_INT64)
+#if defined(JSONCPP_HAS_INT64)
       Value( Int64 value );
       Value( UInt64 value );
-#endif // if defined(JSON_HAS_INT64)
+#endif // if defined(JSONCPP_HAS_INT64)
       Value( double value );
       Value( const char *value );
       Value( const char *beginValue, const char *endValue );
@@ -245,7 +245,7 @@ namespace Json {
        */
       Value( const StaticString &value );
       Value( const std::string &value );
-# ifdef JSON_USE_CPPTL
+# ifdef JSONCPP_USE_CPPTL
       Value( const CppTL::ConstString &value );
 # endif
       Value( bool value );
@@ -272,7 +272,7 @@ namespace Json {
 
       const char *asCString() const;
       std::string asString( const std::string &defaultValue = "" ) const;
-# ifdef JSON_USE_CPPTL
+# ifdef JSONCPP_USE_CPPTL
       CppTL::ConstString asConstString() const;
 # endif
       Int asInt( Value::Int defaultValue = 0 ) const;
@@ -375,7 +375,7 @@ namespace Json {
        * \endcode
        */
       Value &operator[]( const StaticString &key );
-# ifdef JSON_USE_CPPTL
+# ifdef JSONCPP_USE_CPPTL
       /// Access an object value by name, create a null member if it does not exist.
       Value &operator[]( const CppTL::ConstString &key );
       /// Access an object value by name, returns null if there is no member with that name.
@@ -387,7 +387,7 @@ namespace Json {
       /// Return the member named key if it exist, defaultValue otherwise.
       Value get( const std::string &key,
                  const Value &defaultValue ) const;
-# ifdef JSON_USE_CPPTL
+# ifdef JSONCPP_USE_CPPTL
       /// Return the member named key if it exist, defaultValue otherwise.
       Value get( const CppTL::ConstString &key,
                  const Value &defaultValue ) const;
@@ -406,7 +406,7 @@ namespace Json {
       bool isMember( const char *key ) const;
       /// Return true if the object has a member named key.
       bool isMember( const std::string &key ) const;
-# ifdef JSON_USE_CPPTL
+# ifdef JSONCPP_USE_CPPTL
       /// Return true if the object has a member named key.
       bool isMember( const CppTL::ConstString &key ) const;
 # endif
@@ -418,7 +418,7 @@ namespace Json {
       /// \post if type() was nullValue, it remains nullValue
       Members getMemberNames() const;
 
-//# ifdef JSON_USE_CPPTL
+//# ifdef JSONCPP_USE_CPPTL
 //      EnumMemberNames enumMemberNames() const;
 //      EnumValues enumValues() const;
 //# endif
@@ -445,7 +445,7 @@ namespace Json {
       Value &resolveReference( const char *key, 
                                bool isStatic );
 
-# ifdef JSON_VALUE_USE_INTERNAL_MAP
+# ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
       inline bool isItemAvailable() const
       {
          return itemIsUsed_ == 0;
@@ -465,7 +465,7 @@ namespace Json {
       {
          memberNameIsStatic_ = isStatic ? 1 : 0;
       }
-# endif // # ifdef JSON_VALUE_USE_INTERNAL_MAP
+# endif // # ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
 
    private:
       //struct MemberNamesTransform
@@ -484,7 +484,7 @@ namespace Json {
          double real_;
          bool bool_;
          char *string_;
-# ifdef JSON_VALUE_USE_INTERNAL_MAP
+# ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
          ValueInternalArray *array_;
          ValueInternalMap *map_;
 #else
@@ -493,7 +493,7 @@ namespace Json {
       } value_;
       ValueType type_ : 8;
       unsigned int allocated_ : 1;     // Notes: if declared as bool, bitfield is useless.
-# ifdef JSON_VALUE_USE_INTERNAL_MAP
+# ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
       unsigned int itemIsUsed_ : 1;      // used by the ValueInternalMap container.
       int memberNameIsStatic_ : 1;       // used by the ValueInternalMap container.
 # endif
@@ -569,7 +569,7 @@ namespace Json {
 
 
 
-#ifdef JSON_VALUE_USE_INTERNAL_MAP
+#ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    /** \brief Allocator to customize Value internal map.
     * Below is an example of a simple implementation (default implementation actually
     * use memory pool for speed).
@@ -614,7 +614,7 @@ namespace Json {
       };
     * \endcode
     */ 
-   class JSON_API ValueMapAllocator
+   class JSONCPP_API ValueMapAllocator
    {
    public:
       virtual ~ValueMapAllocator();
@@ -630,7 +630,7 @@ namespace Json {
    /** \brief ValueInternalMap hash-map bucket chain link (for internal use only).
     * \internal previous_ & next_ allows for bidirectional traversal.
     */
-   class JSON_API ValueInternalLink
+   class JSONCPP_API ValueInternalLink
    {
    public:
       enum { itemPerLink = 6 };  // sizeof(ValueInternalLink) = 128 on 32 bits architecture.
@@ -662,7 +662,7 @@ namespace Json {
     * Only the last link of a bucket may contains 'available' item. The last link always
     * contains at least one element unless is it the bucket one very first link.
     */
-   class JSON_API ValueInternalMap
+   class JSONCPP_API ValueInternalMap
    {
       friend class ValueIteratorBase;
       friend class Value;
@@ -760,7 +760,7 @@ namespace Json {
    * Insertion is amortized constant time (only the array containing the index of pointers
    * need to be reallocated when items are appended).
    */
-   class JSON_API ValueInternalArray
+   class JSONCPP_API ValueInternalArray
    {
       friend class Value;
       friend class ValueIteratorBase;
@@ -879,7 +879,7 @@ public: // overridden from ValueArrayAllocator
 };
       \endcode
     */ 
-   class JSON_API ValueArrayAllocator
+   class JSONCPP_API ValueArrayAllocator
    {
    public:
       virtual ~ValueArrayAllocator();
@@ -905,7 +905,7 @@ public: // overridden from ValueArrayAllocator
       virtual Value *allocateArrayPage() = 0;
       virtual void releaseArrayPage( Value *value ) = 0;
    };
-#endif // #ifdef JSON_VALUE_USE_INTERNAL_MAP
+#endif // #ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
 
 
    /** \brief base class for Value iterators.
@@ -919,7 +919,7 @@ public: // overridden from ValueArrayAllocator
       typedef ValueIteratorBase SelfType;
 
       ValueIteratorBase();
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
       explicit ValueIteratorBase( const Value::ObjectValues::iterator &current );
 #else
       ValueIteratorBase( const ValueInternalArray::IteratorState &state );
@@ -964,7 +964,7 @@ public: // overridden from ValueArrayAllocator
       void copy( const SelfType &other );
 
    private:
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
       Value::ObjectValues::iterator current_;
       // Indicates that iterator is for a null value.
       bool isNull_;
@@ -995,7 +995,7 @@ public: // overridden from ValueArrayAllocator
    private:
       /*! \internal Use by Value to create an iterator.
        */
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
       explicit ValueConstIterator( const Value::ObjectValues::iterator &current );
 #else
       ValueConstIterator( const ValueInternalArray::IteratorState &state );
@@ -1055,7 +1055,7 @@ public: // overridden from ValueArrayAllocator
    private:
       /*! \internal Use by Value to create an iterator.
        */
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
       explicit ValueIterator( const Value::ObjectValues::iterator &current );
 #else
       ValueIterator( const ValueInternalArray::IteratorState &state );
@@ -1101,4 +1101,4 @@ public: // overridden from ValueArrayAllocator
 } // namespace Json
 
 
-#endif // CPPTL_JSON_H_INCLUDED
+#endif // CPPTL_JSONCPP_H_INCLUDED

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -3,12 +3,12 @@
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
 
-#ifndef JSON_WRITER_H_INCLUDED
-# define JSON_WRITER_H_INCLUDED
+#ifndef JSONCPP_WRITER_H_INCLUDED
+# define JSONCPP_WRITER_H_INCLUDED
 
-#if !defined(JSON_IS_AMALGAMATION)
+#if !defined(JSONCPP_IS_AMALGAMATION)
 # include "value.h"
-#endif // if !defined(JSON_IS_AMALGAMATION)
+#endif // if !defined(JSONCPP_IS_AMALGAMATION)
 # include <vector>
 # include <string>
 # include <iostream>
@@ -19,7 +19,7 @@ namespace Json {
 
    /** \brief Abstract class for writers.
     */
-   class JSON_API Writer
+   class JSONCPP_API Writer
    {
    public:
       virtual ~Writer();
@@ -33,7 +33,7 @@ namespace Json {
     * but may be usefull to support feature such as RPC where bandwith is limited.
     * \sa Reader, Value
     */
-   class JSON_API FastWriter : public Writer
+   class JSONCPP_API FastWriter : public Writer
    {
    public:
       FastWriter();
@@ -69,7 +69,7 @@ namespace Json {
     *
     * \sa Reader, Value, Value::setComment()
     */
-   class JSON_API StyledWriter: public Writer
+   class JSONCPP_API StyledWriter: public Writer
    {
    public:
       StyledWriter();
@@ -126,7 +126,7 @@ namespace Json {
     * \param indentation Each level will be indented by this amount extra.
     * \sa Reader, Value, Value::setComment()
     */
-   class JSON_API StyledStreamWriter
+   class JSONCPP_API StyledStreamWriter
    {
    public:
       StyledStreamWriter( std::string indentation="\t" );
@@ -164,15 +164,15 @@ namespace Json {
       bool addChildValues_;
    };
 
-# if defined(JSON_HAS_INT64)
-   std::string JSON_API valueToString( Int value );
-   std::string JSON_API valueToString( UInt value );
-# endif // if defined(JSON_HAS_INT64)
-   std::string JSON_API valueToString( LargestInt value );
-   std::string JSON_API valueToString( LargestUInt value );
-   std::string JSON_API valueToString( double value );
-   std::string JSON_API valueToString( bool value );
-   std::string JSON_API valueToQuotedString( const char *value );
+# if defined(JSONCPP_HAS_INT64)
+   std::string JSONCPP_API valueToString( Int value );
+   std::string JSONCPP_API valueToString( UInt value );
+# endif // if defined(JSONCPP_HAS_INT64)
+   std::string JSONCPP_API valueToString( LargestInt value );
+   std::string JSONCPP_API valueToString( LargestUInt value );
+   std::string JSONCPP_API valueToString( double value );
+   std::string JSONCPP_API valueToString( bool value );
+   std::string JSONCPP_API valueToQuotedString( const char *value );
 
    /// \brief Output using the StyledStreamWriter.
    /// \see Json::operator>>()
@@ -182,4 +182,4 @@ namespace Json {
 
 
 
-#endif // JSON_WRITER_H_INCLUDED
+#endif // JSONCPP_WRITER_H_INCLUDED

--- a/src/jsontestrunner/main.cpp
+++ b/src/jsontestrunner/main.cpp
@@ -162,10 +162,10 @@ static void
 printConfig()
 {
    // Print the configuration used to compile JsonCpp
-#if defined(JSON_NO_INT64)
-   printf( "JSON_NO_INT64=1\n" );
+#if defined(JSONCPP_NO_INT64)
+   printf( "JSONCPP_NO_INT64=1\n" );
 #else
-   printf( "JSON_NO_INT64=0\n" );
+   printf( "JSONCPP_NO_INT64=0\n" );
 #endif
 }
 

--- a/src/lib_json/json_internalarray.inl
+++ b/src/lib_json/json_internalarray.inl
@@ -22,7 +22,7 @@ ValueArrayAllocator::~ValueArrayAllocator()
 // //////////////////////////////////////////////////////////////////
 // class DefaultValueArrayAllocator
 // //////////////////////////////////////////////////////////////////
-#ifdef JSON_USE_SIMPLE_INTERNAL_ALLOCATOR
+#ifdef JSONCPP_USE_SIMPLE_INTERNAL_ALLOCATOR
 class DefaultValueArrayAllocator : public ValueArrayAllocator
 {
 public: // overridden from ValueArrayAllocator
@@ -77,7 +77,7 @@ public: // overridden from ValueArrayAllocator
    }
 };
 
-#else // #ifdef JSON_USE_SIMPLE_INTERNAL_ALLOCATOR
+#else // #ifdef JSONCPP_USE_SIMPLE_INTERNAL_ALLOCATOR
 /// @todo make this thread-safe (lock when accessign batch allocator)
 class DefaultValueArrayAllocator : public ValueArrayAllocator
 {
@@ -143,7 +143,7 @@ private:
    BatchAllocator<ValueInternalArray,1> arraysAllocator_;
    BatchAllocator<Value,ValueInternalArray::itemsPerPage> pagesAllocator_;
 };
-#endif // #ifdef JSON_USE_SIMPLE_INTERNAL_ALLOCATOR
+#endif // #ifdef JSONCPP_USE_SIMPLE_INTERNAL_ALLOCATOR
 
 static ValueArrayAllocator *&arrayAllocator()
 {
@@ -175,7 +175,7 @@ ValueInternalArray::equals( const IteratorState &x,
 void 
 ValueInternalArray::increment( IteratorState &it )
 {
-   JSON_ASSERT_MESSAGE( it.array_  &&
+   JSONCPP_ASSERT_MESSAGE( it.array_  &&
       (it.currentPageIndex_ - it.array_->pages_)*itemsPerPage + it.currentItemIndex_
       != it.array_->size_,
       "ValueInternalArray::increment(): moving iterator beyond end" );
@@ -191,7 +191,7 @@ ValueInternalArray::increment( IteratorState &it )
 void 
 ValueInternalArray::decrement( IteratorState &it )
 {
-   JSON_ASSERT_MESSAGE( it.array_  &&  it.currentPageIndex_ == it.array_->pages_ 
+   JSONCPP_ASSERT_MESSAGE( it.array_  &&  it.currentPageIndex_ == it.array_->pages_ 
                         &&  it.currentItemIndex_ == 0,
       "ValueInternalArray::decrement(): moving iterator beyond end" );
    if ( it.currentItemIndex_ == 0 )
@@ -216,7 +216,7 @@ ValueInternalArray::unsafeDereference( const IteratorState &it )
 Value &
 ValueInternalArray::dereference( const IteratorState &it )
 {
-   JSON_ASSERT_MESSAGE( it.array_  &&
+   JSONCPP_ASSERT_MESSAGE( it.array_  &&
       (it.currentPageIndex_ - it.array_->pages_)*itemsPerPage + it.currentItemIndex_
       < it.array_->size_,
       "ValueInternalArray::dereference(): dereferencing invalid iterator" );
@@ -263,7 +263,7 @@ ValueInternalArray::ValueInternalArray( const ValueInternalArray &other )
 {
    PageIndex minNewPages = other.size_ / itemsPerPage;
    arrayAllocator()->reallocateArrayPageIndex( pages_, pageCount_, minNewPages );
-   JSON_ASSERT_MESSAGE( pageCount_ >= minNewPages, 
+   JSONCPP_ASSERT_MESSAGE( pageCount_ >= minNewPages, 
                         "ValueInternalArray::reserve(): bad reallocation" );
    IteratorState itOther;
    other.makeBeginIterator( itOther );
@@ -368,7 +368,7 @@ ValueInternalArray::makeIndexValid( ArrayIndex index )
    {
       PageIndex minNewPages = (index + 1) / itemsPerPage;
       arrayAllocator()->reallocateArrayPageIndex( pages_, pageCount_, minNewPages );
-      JSON_ASSERT_MESSAGE( pageCount_ >= minNewPages, "ValueInternalArray::reserve(): bad reallocation" );
+      JSONCPP_ASSERT_MESSAGE( pageCount_ >= minNewPages, "ValueInternalArray::reserve(): bad reallocation" );
    }
 
    // Need to allocate new pages ?

--- a/src/lib_json/json_internalmap.inl
+++ b/src/lib_json/json_internalmap.inl
@@ -44,7 +44,7 @@ ValueMapAllocator::~ValueMapAllocator()
 {
 }
 
-#ifdef JSON_USE_SIMPLE_INTERNAL_ALLOCATOR
+#ifdef JSONCPP_USE_SIMPLE_INTERNAL_ALLOCATOR
 class DefaultValueMapAllocator : public ValueMapAllocator
 {
 public: // overridden from ValueMapAllocator
@@ -435,7 +435,7 @@ ValueInternalMap::unsafeAdd( const char *key,
                              bool isStatic, 
                              HashKey hashedKey )
 {
-   JSON_ASSERT_MESSAGE( bucketsSize_ > 0, "ValueInternalMap::unsafeAdd(): internal logic error." );
+   JSONCPP_ASSERT_MESSAGE( bucketsSize_ > 0, "ValueInternalMap::unsafeAdd(): internal logic error." );
    BucketIndex bucketIndex = hashedKey % bucketsSize_;
    ValueInternalLink *&previousLink = getLastLinkInBucket( bucketIndex );
    ValueInternalLink *link = previousLink;
@@ -531,7 +531,7 @@ void
 ValueInternalMap::incrementBucket( IteratorState &iterator )
 {
    ++iterator.bucketIndex_;
-   JSON_ASSERT_MESSAGE( iterator.bucketIndex_ <= iterator.map_->bucketsSize_,
+   JSONCPP_ASSERT_MESSAGE( iterator.bucketIndex_ <= iterator.map_->bucketsSize_,
       "ValueInternalMap::increment(): attempting to iterate beyond end." );
    if ( iterator.bucketIndex_ == iterator.map_->bucketsSize_ )
       iterator.link_ = 0;
@@ -544,11 +544,11 @@ ValueInternalMap::incrementBucket( IteratorState &iterator )
 void 
 ValueInternalMap::increment( IteratorState &iterator )
 {
-   JSON_ASSERT_MESSAGE( iterator.map_, "Attempting to iterator using invalid iterator." );
+   JSONCPP_ASSERT_MESSAGE( iterator.map_, "Attempting to iterator using invalid iterator." );
    ++iterator.itemIndex_;
    if ( iterator.itemIndex_ == ValueInternalLink::itemPerLink )
    {
-      JSON_ASSERT_MESSAGE( iterator.link_ != 0,
+      JSONCPP_ASSERT_MESSAGE( iterator.link_ != 0,
          "ValueInternalMap::increment(): attempting to iterate beyond end." );
       iterator.link_ = iterator.link_->next_;
       if ( iterator.link_ == 0 )
@@ -566,10 +566,10 @@ ValueInternalMap::decrement( IteratorState &iterator )
 {
    if ( iterator.itemIndex_ == 0 )
    {
-      JSON_ASSERT_MESSAGE( iterator.map_, "Attempting to iterate using invalid iterator." );
+      JSONCPP_ASSERT_MESSAGE( iterator.map_, "Attempting to iterate using invalid iterator." );
       if ( iterator.link_ == &iterator.map_->buckets_[iterator.bucketIndex_] )
       {
-         JSON_ASSERT_MESSAGE( iterator.bucketIndex_ > 0, "Attempting to iterate beyond beginning." );
+         JSONCPP_ASSERT_MESSAGE( iterator.bucketIndex_ > 0, "Attempting to iterate beyond beginning." );
          --(iterator.bucketIndex_);
       }
       iterator.link_ = iterator.link_->previous_;
@@ -581,14 +581,14 @@ ValueInternalMap::decrement( IteratorState &iterator )
 const char *
 ValueInternalMap::key( const IteratorState &iterator )
 {
-   JSON_ASSERT_MESSAGE( iterator.link_, "Attempting to iterate using invalid iterator." );
+   JSONCPP_ASSERT_MESSAGE( iterator.link_, "Attempting to iterate using invalid iterator." );
    return iterator.link_->keys_[iterator.itemIndex_];
 }
 
 const char *
 ValueInternalMap::key( const IteratorState &iterator, bool &isStatic )
 {
-   JSON_ASSERT_MESSAGE( iterator.link_, "Attempting to iterate using invalid iterator." );
+   JSONCPP_ASSERT_MESSAGE( iterator.link_, "Attempting to iterate using invalid iterator." );
    isStatic = iterator.link_->items_[iterator.itemIndex_].isMemberNameStatic();
    return iterator.link_->keys_[iterator.itemIndex_];
 }
@@ -597,7 +597,7 @@ ValueInternalMap::key( const IteratorState &iterator, bool &isStatic )
 Value &
 ValueInternalMap::value( const IteratorState &iterator )
 {
-   JSON_ASSERT_MESSAGE( iterator.link_, "Attempting to iterate using invalid iterator." );
+   JSONCPP_ASSERT_MESSAGE( iterator.link_, "Attempting to iterate using invalid iterator." );
    return iterator.link_->items_[iterator.itemIndex_];
 }
 

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -3,11 +3,11 @@
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
 
-#if !defined(JSON_IS_AMALGAMATION)
+#if !defined(JSONCPP_IS_AMALGAMATION)
 # include <json/reader.h>
 # include <json/value.h>
 # include "json_tool.h"
-#endif // if !defined(JSON_IS_AMALGAMATION)
+#endif // if !defined(JSONCPP_IS_AMALGAMATION)
 #include <utility>
 #include <cstdio>
 #include <cassert>
@@ -871,8 +871,8 @@ std::istream& operator>>( std::istream &sin, Value &root )
 {
     Json::Reader reader;
     bool ok = reader.parse(sin, root, true);
-    //JSON_ASSERT( ok );
-    if (!ok) JSON_FAIL_MESSAGE(reader.getFormattedErrorMessages());
+    //JSONCPP_ASSERT( ok );
+    if (!ok) JSONCPP_FAIL_MESSAGE(reader.getFormattedErrorMessages());
     return sin;
 }
 

--- a/src/lib_json/json_tool.h
+++ b/src/lib_json/json_tool.h
@@ -3,8 +3,8 @@
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
 
-#ifndef LIB_JSONCPP_JSON_TOOL_H_INCLUDED
-# define LIB_JSONCPP_JSON_TOOL_H_INCLUDED
+#ifndef LIB_JSONCPP_JSONCPP_TOOL_H_INCLUDED
+# define LIB_JSONCPP_JSONCPP_TOOL_H_INCLUDED
 
 /* This header provides common string manipulation support, such as UTF-8,
  * portable conversion from/to string...
@@ -90,4 +90,4 @@ uintToString( LargestUInt value,
 
 } // namespace Json {
 
-#endif // LIB_JSONCPP_JSON_TOOL_H_INCLUDED
+#endif // LIB_JSONCPP_JSONCPP_TOOL_H_INCLUDED

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -3,19 +3,19 @@
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
 
-#if !defined(JSON_IS_AMALGAMATION)
+#if !defined(JSONCPP_IS_AMALGAMATION)
 # include <json/value.h>
 # include <json/writer.h>
-# ifndef JSON_USE_SIMPLE_INTERNAL_ALLOCATOR
+# ifndef JSONCPP_USE_SIMPLE_INTERNAL_ALLOCATOR
 #  include "json_batchallocator.h"
-# endif // #ifndef JSON_USE_SIMPLE_INTERNAL_ALLOCATOR
-#endif // if !defined(JSON_IS_AMALGAMATION)
+# endif // #ifndef JSONCPP_USE_SIMPLE_INTERNAL_ALLOCATOR
+#endif // if !defined(JSONCPP_IS_AMALGAMATION)
 #include <iostream>
 #include <utility>
 #include <stdexcept>
 #include <cstring>
 #include <cassert>
-#ifdef JSON_USE_CPPTL
+#ifdef JSONCPP_USE_CPPTL
 # include <cpptl/conststring.h>
 #endif
 #include <cstddef>    // size_t
@@ -53,7 +53,7 @@ duplicateStringValue( const char *value,
    if ( length == unknown )
       length = (unsigned int)strlen(value);
    char *newString = static_cast<char *>( malloc( length + 1 ) );
-   JSON_ASSERT_MESSAGE( newString != 0, "Failed to allocate string value buffer" );
+   JSONCPP_ASSERT_MESSAGE( newString != 0, "Failed to allocate string value buffer" );
    memcpy( newString, value, length );
    newString[length] = 0;
    return newString;
@@ -79,14 +79,14 @@ releaseStringValue( char *value )
 // //////////////////////////////////////////////////////////////////
 // //////////////////////////////////////////////////////////////////
 // //////////////////////////////////////////////////////////////////
-#if !defined(JSON_IS_AMALGAMATION)
-# ifdef JSON_VALUE_USE_INTERNAL_MAP
+#if !defined(JSONCPP_IS_AMALGAMATION)
+# ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
 #  include "json_internalarray.inl"
 #  include "json_internalmap.inl"
-# endif // JSON_VALUE_USE_INTERNAL_MAP
+# endif // JSONCPP_VALUE_USE_INTERNAL_MAP
 
 # include "json_valueiterator.inl"
-#endif // if !defined(JSON_IS_AMALGAMATION)
+#endif // if !defined(JSONCPP_IS_AMALGAMATION)
 
 namespace Json {
 
@@ -97,7 +97,7 @@ namespace Json {
 // //////////////////////////////////////////////////////////////////
 // //////////////////////////////////////////////////////////////////
 // //////////////////////////////////////////////////////////////////
-# ifndef JSON_VALUE_USE_INTERNAL_MAP
+# ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
 
 // Notes: index_ indicates if the string was allocated when
 // a string is stored.
@@ -181,7 +181,7 @@ Value::CZString::isStaticString() const
    return index_ == noDuplication;
 }
 
-#endif // ifndef JSON_VALUE_USE_INTERNAL_MAP
+#endif // ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
 
 
 // //////////////////////////////////////////////////////////////////
@@ -199,7 +199,7 @@ Value::CZString::isStaticString() const
 Value::Value( ValueType type )
    : type_( type )
    , allocated_( 0 )
-# ifdef JSON_VALUE_USE_INTERNAL_MAP
+# ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    , itemIsUsed_( 0 )
 #endif
 {
@@ -217,7 +217,7 @@ Value::Value( ValueType type )
    case stringValue:
       value_.string_ = 0;
       break;
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    case arrayValue:
    case objectValue:
       value_.map_ = new ObjectValues();
@@ -234,15 +234,15 @@ Value::Value( ValueType type )
       value_.bool_ = false;
       break;
    default:
-      JSON_ASSERT_UNREACHABLE;
+      JSONCPP_ASSERT_UNREACHABLE;
    }
 }
 
 
-#if defined(JSON_HAS_INT64)
+#if defined(JSONCPP_HAS_INT64)
 Value::Value( UInt value )
    : type_( uintValue )
-# ifdef JSON_VALUE_USE_INTERNAL_MAP
+# ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    , itemIsUsed_( 0 )
 #endif
 {
@@ -251,19 +251,19 @@ Value::Value( UInt value )
 
 Value::Value( Int value )
    : type_( intValue )
-# ifdef JSON_VALUE_USE_INTERNAL_MAP
+# ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    , itemIsUsed_( 0 )
 #endif
 {
    value_.int_ = value;
 }
 
-#endif // if defined(JSON_HAS_INT64)
+#endif // if defined(JSONCPP_HAS_INT64)
 
 
 Value::Value( Int64 value )
    : type_( intValue )
-# ifdef JSON_VALUE_USE_INTERNAL_MAP
+# ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    , itemIsUsed_( 0 )
 #endif
 {
@@ -273,7 +273,7 @@ Value::Value( Int64 value )
 
 Value::Value( UInt64 value )
    : type_( uintValue )
-# ifdef JSON_VALUE_USE_INTERNAL_MAP
+# ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    , itemIsUsed_( 0 )
 #endif
 {
@@ -282,7 +282,7 @@ Value::Value( UInt64 value )
 
 Value::Value( double value )
    : type_( realValue )
-# ifdef JSON_VALUE_USE_INTERNAL_MAP
+# ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    , itemIsUsed_( 0 )
 #endif
 {
@@ -292,7 +292,7 @@ Value::Value( double value )
 Value::Value( const char *value )
    : type_( stringValue )
    , allocated_( true )
-# ifdef JSON_VALUE_USE_INTERNAL_MAP
+# ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    , itemIsUsed_( 0 )
 #endif
 {
@@ -304,7 +304,7 @@ Value::Value( const char *beginValue,
               const char *endValue )
    : type_( stringValue )
    , allocated_( true )
-# ifdef JSON_VALUE_USE_INTERNAL_MAP
+# ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    , itemIsUsed_( 0 )
 #endif
 {
@@ -316,7 +316,7 @@ Value::Value( const char *beginValue,
 Value::Value( const std::string &value )
    : type_( stringValue )
    , allocated_( true )
-# ifdef JSON_VALUE_USE_INTERNAL_MAP
+# ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    , itemIsUsed_( 0 )
 #endif
 {
@@ -328,7 +328,7 @@ Value::Value( const std::string &value )
 Value::Value( const StaticString &value )
    : type_( stringValue )
    , allocated_( false )
-# ifdef JSON_VALUE_USE_INTERNAL_MAP
+# ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    , itemIsUsed_( 0 )
 #endif
 {
@@ -336,11 +336,11 @@ Value::Value( const StaticString &value )
 }
 
 
-# ifdef JSON_USE_CPPTL
+# ifdef JSONCPP_USE_CPPTL
 Value::Value( const CppTL::ConstString &value )
    : type_( stringValue )
    , allocated_( true )
-# ifdef JSON_VALUE_USE_INTERNAL_MAP
+# ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    , itemIsUsed_( 0 )
 #endif
 {
@@ -350,7 +350,7 @@ Value::Value( const CppTL::ConstString &value )
 
 Value::Value( bool value )
    : type_( booleanValue )
-# ifdef JSON_VALUE_USE_INTERNAL_MAP
+# ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    , itemIsUsed_( 0 )
 #endif
 {
@@ -360,7 +360,7 @@ Value::Value( bool value )
 
 Value::Value( const Value &other )
    : type_( other.type_ )
-# ifdef JSON_VALUE_USE_INTERNAL_MAP
+# ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    , itemIsUsed_( 0 )
 #endif
 {
@@ -382,7 +382,7 @@ Value::Value( const Value &other )
       else
          value_.string_ = 0;
       break;
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    case arrayValue:
    case objectValue:
       value_.map_ = new ObjectValues( *other.value_.map_ );
@@ -396,7 +396,7 @@ Value::Value( const Value &other )
       break;
 #endif
    default:
-      JSON_ASSERT_UNREACHABLE;
+      JSONCPP_ASSERT_UNREACHABLE;
    }
 }
 
@@ -415,7 +415,7 @@ Value::~Value()
       if ( allocated_ )
          releaseStringValue( value_.string_ );
       break;
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    case arrayValue:
    case objectValue:
       delete value_.map_;
@@ -429,7 +429,7 @@ Value::~Value()
       break;
 #endif
    default:
-      JSON_ASSERT_UNREACHABLE;
+      JSONCPP_ASSERT_UNREACHABLE;
    }
 }
 
@@ -494,7 +494,7 @@ Value::operator <( const Value &other ) const
              || ( other.value_.string_  
                   &&  value_.string_  
                   && strcmp( value_.string_, other.value_.string_ ) < 0 );
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    case arrayValue:
    case objectValue:
       {
@@ -510,7 +510,7 @@ Value::operator <( const Value &other ) const
       return value_.map_->compare( *(other.value_.map_) ) < 0;
 #endif
    default:
-      JSON_ASSERT_UNREACHABLE;
+      JSONCPP_ASSERT_UNREACHABLE;
    }
    return false;  // unreachable
 }
@@ -560,7 +560,7 @@ Value::operator ==( const Value &other ) const
              || ( other.value_.string_  
                   &&  value_.string_  
                   && strcmp( value_.string_, other.value_.string_ ) == 0 );
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    case arrayValue:
    case objectValue:
       return value_.map_->size() == other.value_.map_->size()
@@ -572,7 +572,7 @@ Value::operator ==( const Value &other ) const
       return value_.map_->compare( *(other.value_.map_) ) == 0;
 #endif
    default:
-      JSON_ASSERT_UNREACHABLE;
+      JSONCPP_ASSERT_UNREACHABLE;
    }
    return false;  // unreachable
 }
@@ -586,7 +586,7 @@ Value::operator !=( const Value &other ) const
 const char *
 Value::asCString() const
 {
-   JSON_ASSERT( type_ == stringValue );
+   JSONCPP_ASSERT( type_ == stringValue );
    return value_.string_;
 }
 
@@ -607,16 +607,16 @@ Value::asString( const std::string& defaultValue ) const
    case realValue:
    case arrayValue:
    case objectValue: {
-      JSON_FAIL_MESSAGE( "Type is not convertible to string" );
+      JSONCPP_FAIL_MESSAGE( "Type is not convertible to string" );
       break;
    }
    default:
-      JSON_ASSERT_UNREACHABLE;
+      JSONCPP_ASSERT_UNREACHABLE;
    }
    return defaultValue; // unreachable
 }
 
-# ifdef JSON_USE_CPPTL
+# ifdef JSONCPP_USE_CPPTL
 CppTL::ConstString 
 Value::asConstString() const
 {
@@ -633,24 +633,24 @@ Value::asInt( Value::Int defaultValue ) const
    case nullValue:
       return defaultValue;
    case intValue:
-      JSON_ASSERT_MESSAGE( value_.int_ >= minInt  &&  value_.int_ <= maxInt, "unsigned integer out of signed int range" );
+      JSONCPP_ASSERT_MESSAGE( value_.int_ >= minInt  &&  value_.int_ <= maxInt, "unsigned integer out of signed int range" );
       return Int(value_.int_);
    case uintValue:
-      JSON_ASSERT_MESSAGE( value_.uint_ <= UInt(maxInt), "unsigned integer out of signed int range" );
+      JSONCPP_ASSERT_MESSAGE( value_.uint_ <= UInt(maxInt), "unsigned integer out of signed int range" );
       return Int(value_.uint_);
    case realValue:
-      JSON_ASSERT_MESSAGE( value_.real_ >= minInt  &&  value_.real_ <= maxInt, "Real out of signed integer range" );
+      JSONCPP_ASSERT_MESSAGE( value_.real_ >= minInt  &&  value_.real_ <= maxInt, "Real out of signed integer range" );
       return Int( value_.real_ );
    case booleanValue:
       return value_.bool_ ? 1 : 0;
    case stringValue:
    case arrayValue:
    case objectValue: {
-      JSON_FAIL_MESSAGE( "Type is not convertible to int" );
+      JSONCPP_FAIL_MESSAGE( "Type is not convertible to int" );
       break;
    }
    default:
-      JSON_ASSERT_UNREACHABLE;
+      JSONCPP_ASSERT_UNREACHABLE;
    }
    return defaultValue; // unreachable;
 }
@@ -664,31 +664,31 @@ Value::asUInt( Value::UInt defaultValue ) const
    case nullValue:
       return defaultValue;
    case intValue:
-      JSON_ASSERT_MESSAGE( value_.int_ >= 0, "Negative integer can not be converted to unsigned integer" );
-      JSON_ASSERT_MESSAGE( value_.int_ <= maxUInt, "signed integer out of UInt range" );
+      JSONCPP_ASSERT_MESSAGE( value_.int_ >= 0, "Negative integer can not be converted to unsigned integer" );
+      JSONCPP_ASSERT_MESSAGE( value_.int_ <= maxUInt, "signed integer out of UInt range" );
       return UInt(value_.int_);
    case uintValue:
-      JSON_ASSERT_MESSAGE( value_.uint_ <= maxUInt, "unsigned integer out of UInt range" );
+      JSONCPP_ASSERT_MESSAGE( value_.uint_ <= maxUInt, "unsigned integer out of UInt range" );
       return UInt(value_.uint_);
    case realValue:
-      JSON_ASSERT_MESSAGE( value_.real_ >= 0  &&  value_.real_ <= maxUInt,  "Real out of unsigned integer range" );
+      JSONCPP_ASSERT_MESSAGE( value_.real_ >= 0  &&  value_.real_ <= maxUInt,  "Real out of unsigned integer range" );
       return UInt( value_.real_ );
    case booleanValue:
       return value_.bool_ ? 1 : 0;
    case stringValue:
    case arrayValue:
    case objectValue: {
-      JSON_FAIL_MESSAGE( "Type is not convertible to uint" );
+      JSONCPP_FAIL_MESSAGE( "Type is not convertible to uint" );
       break;
    }
    default:
-      JSON_ASSERT_UNREACHABLE;
+      JSONCPP_ASSERT_UNREACHABLE;
    }
    return defaultValue; // unreachable;
 }
 
 
-# if defined(JSON_HAS_INT64)
+# if defined(JSONCPP_HAS_INT64)
 
 Value::Int64
 Value::asInt64( Value::Int64 defaultValue ) const
@@ -700,21 +700,21 @@ Value::asInt64( Value::Int64 defaultValue ) const
    case intValue:
       return value_.int_;
    case uintValue:
-      JSON_ASSERT_MESSAGE( value_.uint_ <= UInt64(maxInt64), "unsigned integer out of Int64 range" );
+      JSONCPP_ASSERT_MESSAGE( value_.uint_ <= UInt64(maxInt64), "unsigned integer out of Int64 range" );
       return value_.uint_;
    case realValue:
-      JSON_ASSERT_MESSAGE( value_.real_ >= std::nextafter(static_cast<double>(minInt64), 0.0)  &&  value_.real_ <= std::nextafter(static_cast<double>(maxInt64), 0.0), "Real out of Int64 range" );
+      JSONCPP_ASSERT_MESSAGE( value_.real_ >= std::nextafter(static_cast<double>(minInt64), 0.0)  &&  value_.real_ <= std::nextafter(static_cast<double>(maxInt64), 0.0), "Real out of Int64 range" );
       return Int( value_.real_ );
    case booleanValue:
       return value_.bool_ ? 1 : 0;
    case stringValue:
    case arrayValue:
    case objectValue: {
-      JSON_FAIL_MESSAGE( "Type is not convertible to Int64" );
+      JSONCPP_FAIL_MESSAGE( "Type is not convertible to Int64" );
       break;
    }
    default:
-      JSON_ASSERT_UNREACHABLE;
+      JSONCPP_ASSERT_UNREACHABLE;
    }
    return defaultValue; // unreachable;
 }
@@ -728,33 +728,33 @@ Value::asUInt64( Value::UInt64 defaultValue ) const
    case nullValue:
       return defaultValue;
    case intValue:
-      JSON_ASSERT_MESSAGE( value_.int_ >= 0, "Negative integer can not be converted to UInt64" );
+      JSONCPP_ASSERT_MESSAGE( value_.int_ >= 0, "Negative integer can not be converted to UInt64" );
       return value_.int_;
    case uintValue:
       return value_.uint_;
    case realValue:
-      JSON_ASSERT_MESSAGE( value_.real_ >= 0  &&  value_.real_ <= std::nextafter(static_cast<double>(maxUInt64), 0.0),  "Real out of UInt64 range" );
+      JSONCPP_ASSERT_MESSAGE( value_.real_ >= 0  &&  value_.real_ <= std::nextafter(static_cast<double>(maxUInt64), 0.0),  "Real out of UInt64 range" );
       return UInt( value_.real_ );
    case booleanValue:
       return value_.bool_ ? 1 : 0;
    case stringValue:
    case arrayValue:
    case objectValue: {
-      JSON_FAIL_MESSAGE( "Type is not convertible to UInt64" );
+      JSONCPP_FAIL_MESSAGE( "Type is not convertible to UInt64" );
       break;
    }
    default:
-      JSON_ASSERT_UNREACHABLE;
+      JSONCPP_ASSERT_UNREACHABLE;
    }
    return defaultValue; // unreachable;
 }
-# endif // if defined(JSON_HAS_INT64)
+# endif // if defined(JSONCPP_HAS_INT64)
 
 
 LargestInt 
 Value::asLargestInt() const
 {
-#if defined(JSON_NO_INT64)
+#if defined(JSONCPP_NO_INT64)
     return asInt( 0 );
 #else
     return asInt64( 0 );
@@ -765,7 +765,7 @@ Value::asLargestInt() const
 LargestUInt 
 Value::asLargestUInt() const
 {
-#if defined(JSON_NO_INT64)
+#if defined(JSONCPP_NO_INT64)
     return asUInt( 0 );
 #else
     return asUInt64( 0 );
@@ -783,11 +783,11 @@ Value::asDouble( double defaultValue ) const
    case intValue:
       return static_cast<double>( value_.int_ );
    case uintValue:
-#if !defined(JSON_USE_INT64_DOUBLE_CONVERSION)
+#if !defined(JSONCPP_USE_INT64_DOUBLE_CONVERSION)
       return static_cast<double>( value_.uint_ );
-#else // if !defined(JSON_USE_INT64_DOUBLE_CONVERSION)
+#else // if !defined(JSONCPP_USE_INT64_DOUBLE_CONVERSION)
       return static_cast<double>( Int(value_.uint_/2) ) * 2 + Int(value_.uint_ & 1);
-#endif // if !defined(JSON_USE_INT64_DOUBLE_CONVERSION)
+#endif // if !defined(JSONCPP_USE_INT64_DOUBLE_CONVERSION)
    case realValue:
       return value_.real_;
    case booleanValue:
@@ -795,11 +795,11 @@ Value::asDouble( double defaultValue ) const
    case stringValue:
    case arrayValue:
    case objectValue: {
-      JSON_FAIL_MESSAGE( "Type is not convertible to double" );
+      JSONCPP_FAIL_MESSAGE( "Type is not convertible to double" );
       break;
    }
    default:
-      JSON_ASSERT_UNREACHABLE;
+      JSONCPP_ASSERT_UNREACHABLE;
    }
    return defaultValue; // unreachable;
 }
@@ -814,11 +814,11 @@ Value::asFloat( float defaultValue ) const
    case intValue:
       return static_cast<float>( value_.int_ );
    case uintValue:
-#if !defined(JSON_USE_INT64_DOUBLE_CONVERSION)
+#if !defined(JSONCPP_USE_INT64_DOUBLE_CONVERSION)
       return static_cast<float>( value_.uint_ );
-#else // if !defined(JSON_USE_INT64_DOUBLE_CONVERSION)
+#else // if !defined(JSONCPP_USE_INT64_DOUBLE_CONVERSION)
       return static_cast<float>( Int(value_.uint_/2) ) * 2 + Int(value_.uint_ & 1);
-#endif // if !defined(JSON_USE_INT64_DOUBLE_CONVERSION)
+#endif // if !defined(JSONCPP_USE_INT64_DOUBLE_CONVERSION)
    case realValue:
       return static_cast<float>( value_.real_ );
    case booleanValue:
@@ -826,11 +826,11 @@ Value::asFloat( float defaultValue ) const
    case stringValue:
    case arrayValue:
    case objectValue: {
-      JSON_FAIL_MESSAGE( "Type is not convertible to float" );
+      JSONCPP_FAIL_MESSAGE( "Type is not convertible to float" );
       break;
    }
    default:
-      JSON_ASSERT_UNREACHABLE;
+      JSONCPP_ASSERT_UNREACHABLE;
    }
    return defaultValue; // unreachable;
 }
@@ -855,7 +855,7 @@ Value::asBool( bool defaultValue ) const
    case objectValue:
       return value_.map_->size() != 0;
    default:
-      JSON_ASSERT_UNREACHABLE;
+      JSONCPP_ASSERT_UNREACHABLE;
    }
    return defaultValue; // unreachable;
 }
@@ -906,7 +906,7 @@ Value::isConvertibleTo( ValueType other ) const
       return other == objectValue
              ||  ( other == nullValue  &&  value_.map_->size() == 0 );
    default:
-      JSON_ASSERT_UNREACHABLE;
+      JSONCPP_ASSERT_UNREACHABLE;
    }
    return false; // unreachable;
 }
@@ -925,7 +925,7 @@ Value::size() const
    case booleanValue:
    case stringValue:
       return 0;
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    case arrayValue:  // size of the array is highest index + 1
       if ( !value_.map_->empty() )
       {
@@ -943,7 +943,7 @@ Value::size() const
       return Int( value_.map_->size() );
 #endif
    default:
-      JSON_ASSERT_UNREACHABLE;
+      JSONCPP_ASSERT_UNREACHABLE;
    }
    return 0; // unreachable;
 }
@@ -969,11 +969,11 @@ Value::operator!() const
 void 
 Value::clear()
 {
-   JSON_ASSERT( type_ == nullValue  ||  type_ == arrayValue  || type_ == objectValue );
+   JSONCPP_ASSERT( type_ == nullValue  ||  type_ == arrayValue  || type_ == objectValue );
 
    switch ( type_ )
    {
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    case arrayValue:
    case objectValue:
       value_.map_->clear();
@@ -994,10 +994,10 @@ Value::clear()
 void 
 Value::resize( ArrayIndex newSize )
 {
-   JSON_ASSERT( type_ == nullValue  ||  type_ == arrayValue );
+   JSONCPP_ASSERT( type_ == nullValue  ||  type_ == arrayValue );
    if ( type_ == nullValue )
       *this = Value( arrayValue );
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    ArrayIndex oldSize = size();
    if ( newSize == 0 )
       clear();
@@ -1020,10 +1020,10 @@ Value::resize( ArrayIndex newSize )
 Value &
 Value::operator[]( ArrayIndex index )
 {
-   JSON_ASSERT( type_ == nullValue  ||  type_ == arrayValue );
+   JSONCPP_ASSERT( type_ == nullValue  ||  type_ == arrayValue );
    if ( type_ == nullValue )
       *this = Value( arrayValue );
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    CZString key( index );
    ObjectValues::iterator it = value_.map_->lower_bound( key );
    if ( it != value_.map_->end()  &&  (*it).first == key )
@@ -1041,7 +1041,7 @@ Value::operator[]( ArrayIndex index )
 Value &
 Value::operator[]( int index )
 {
-   JSON_ASSERT( index >= 0 );
+   JSONCPP_ASSERT( index >= 0 );
    return (*this)[ ArrayIndex(index) ];
 }
 
@@ -1049,10 +1049,10 @@ Value::operator[]( int index )
 const Value &
 Value::operator[]( ArrayIndex index ) const
 {
-   JSON_ASSERT( type_ == nullValue  ||  type_ == arrayValue );
+   JSONCPP_ASSERT( type_ == nullValue  ||  type_ == arrayValue );
    if ( type_ == nullValue )
       return null;
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    CZString key( index );
    ObjectValues::const_iterator it = value_.map_->find( key );
    if ( it == value_.map_->end() )
@@ -1068,7 +1068,7 @@ Value::operator[]( ArrayIndex index ) const
 const Value &
 Value::operator[]( int index ) const
 {
-   JSON_ASSERT( index >= 0 );
+   JSONCPP_ASSERT( index >= 0 );
    return (*this)[ ArrayIndex(index) ];
 }
 
@@ -1084,10 +1084,10 @@ Value &
 Value::resolveReference( const char *key, 
                          bool isStatic )
 {
-   JSON_ASSERT( type_ == nullValue  ||  type_ == objectValue );
+   JSONCPP_ASSERT( type_ == nullValue  ||  type_ == objectValue );
    if ( type_ == nullValue )
       *this = Value( objectValue );
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    CZString actualKey( key, isStatic ? CZString::noDuplication 
                                      : CZString::duplicateOnCopy );
    ObjectValues::iterator it = value_.map_->lower_bound( actualKey );
@@ -1124,10 +1124,10 @@ Value::isValidIndex( ArrayIndex index ) const
 const Value &
 Value::operator[]( const char *key ) const
 {
-   JSON_ASSERT( type_ == nullValue  ||  type_ == objectValue );
+   JSONCPP_ASSERT( type_ == nullValue  ||  type_ == objectValue );
    if ( type_ == nullValue )
       return null;
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    CZString actualKey( key, CZString::noDuplication );
    ObjectValues::const_iterator it = value_.map_->find( actualKey );
    if ( it == value_.map_->end() )
@@ -1160,7 +1160,7 @@ Value::operator[]( const StaticString &key )
 }
 
 
-# ifdef JSON_USE_CPPTL
+# ifdef JSONCPP_USE_CPPTL
 Value &
 Value::operator[]( const CppTL::ConstString &key )
 {
@@ -1202,10 +1202,10 @@ Value::get( const std::string &key,
 Value
 Value::removeMember( const char* key )
 {
-   JSON_ASSERT( type_ == nullValue  ||  type_ == objectValue );
+   JSONCPP_ASSERT( type_ == nullValue  ||  type_ == objectValue );
    if ( type_ == nullValue )
       return null;
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    CZString actualKey( key, CZString::noDuplication );
    ObjectValues::iterator it = value_.map_->find( actualKey );
    if ( it == value_.map_->end() )
@@ -1231,7 +1231,7 @@ Value::removeMember( const std::string &key )
    return removeMember( key.c_str() );
 }
 
-# ifdef JSON_USE_CPPTL
+# ifdef JSONCPP_USE_CPPTL
 Value 
 Value::get( const CppTL::ConstString &key,
             const Value &defaultValue ) const
@@ -1255,7 +1255,7 @@ Value::isMember( const std::string &key ) const
 }
 
 
-# ifdef JSON_USE_CPPTL
+# ifdef JSONCPP_USE_CPPTL
 bool 
 Value::isMember( const CppTL::ConstString &key ) const
 {
@@ -1266,12 +1266,12 @@ Value::isMember( const CppTL::ConstString &key ) const
 Value::Members 
 Value::getMemberNames() const
 {
-   JSON_ASSERT( type_ == nullValue  ||  type_ == objectValue );
+   JSONCPP_ASSERT( type_ == nullValue  ||  type_ == objectValue );
    if ( type_ == nullValue )
        return Value::Members();
    Members members;
    members.reserve( value_.map_->size() );
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    ObjectValues::const_iterator it = value_.map_->begin();
    ObjectValues::const_iterator itEnd = value_.map_->end();
    for ( ; it != itEnd; ++it )
@@ -1287,7 +1287,7 @@ Value::getMemberNames() const
    return members;
 }
 //
-//# ifdef JSON_USE_CPPTL
+//# ifdef JSONCPP_USE_CPPTL
 //EnumMemberNames
 //Value::enumMemberNames() const
 //{
@@ -1426,7 +1426,7 @@ Value::begin() const
 {
    switch ( type_ )
    {
-#ifdef JSON_VALUE_USE_INTERNAL_MAP
+#ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    case arrayValue:
       if ( value_.array_ )
       {
@@ -1461,7 +1461,7 @@ Value::end() const
 {
    switch ( type_ )
    {
-#ifdef JSON_VALUE_USE_INTERNAL_MAP
+#ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    case arrayValue:
       if ( value_.array_ )
       {
@@ -1497,7 +1497,7 @@ Value::begin()
 {
    switch ( type_ )
    {
-#ifdef JSON_VALUE_USE_INTERNAL_MAP
+#ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    case arrayValue:
       if ( value_.array_ )
       {
@@ -1532,7 +1532,7 @@ Value::end()
 {
    switch ( type_ )
    {
-#ifdef JSON_VALUE_USE_INTERNAL_MAP
+#ifdef JSONCPP_VALUE_USE_INTERNAL_MAP
    case arrayValue:
       if ( value_.array_ )
       {

--- a/src/lib_json/json_valueiterator.inl
+++ b/src/lib_json/json_valueiterator.inl
@@ -16,7 +16,7 @@ namespace Json {
 // //////////////////////////////////////////////////////////////////
 
 ValueIteratorBase::ValueIteratorBase()
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    : current_()
    , isNull_( true )
 {
@@ -30,7 +30,7 @@ ValueIteratorBase::ValueIteratorBase()
 #endif
 
 
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
 ValueIteratorBase::ValueIteratorBase( const Value::ObjectValues::iterator &current )
    : current_( current )
    , isNull_( false )
@@ -54,7 +54,7 @@ ValueIteratorBase::ValueIteratorBase( const ValueInternalMap::IteratorState &sta
 Value &
 ValueIteratorBase::deref() const
 {
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    return current_->second;
 #else
    if ( isArray_ )
@@ -67,7 +67,7 @@ ValueIteratorBase::deref() const
 void 
 ValueIteratorBase::increment()
 {
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    ++current_;
 #else
    if ( isArray_ )
@@ -80,7 +80,7 @@ ValueIteratorBase::increment()
 void 
 ValueIteratorBase::decrement()
 {
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    --current_;
 #else
    if ( isArray_ )
@@ -93,8 +93,8 @@ ValueIteratorBase::decrement()
 ValueIteratorBase::difference_type 
 ValueIteratorBase::computeDistance( const SelfType &other ) const
 {
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
-# ifdef JSON_USE_CPPTL_SMALLMAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
+# ifdef JSONCPP_USE_CPPTL_SMALLMAP
    return current_ - other.current_;
 # else
    // Iterator for null value are initialized using the default
@@ -130,7 +130,7 @@ ValueIteratorBase::computeDistance( const SelfType &other ) const
 bool 
 ValueIteratorBase::isEqual( const SelfType &other ) const
 {
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    if ( isNull_ )
    {
       return other.isNull_;
@@ -147,7 +147,7 @@ ValueIteratorBase::isEqual( const SelfType &other ) const
 void 
 ValueIteratorBase::copy( const SelfType &other )
 {
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    current_ = other.current_;
 #else
    if ( isArray_ )
@@ -160,7 +160,7 @@ ValueIteratorBase::copy( const SelfType &other )
 Value 
 ValueIteratorBase::key() const
 {
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    const Value::CZString czstring = (*current_).first;
    if ( czstring.c_str() )
    {
@@ -184,7 +184,7 @@ ValueIteratorBase::key() const
 UInt 
 ValueIteratorBase::index() const
 {
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    const Value::CZString czstring = (*current_).first;
    if ( !czstring.c_str() )
       return czstring.index();
@@ -200,7 +200,7 @@ ValueIteratorBase::index() const
 const char *
 ValueIteratorBase::memberName() const
 {
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
    const char *name = (*current_).first.c_str();
    return name ? name : "";
 #else
@@ -224,7 +224,7 @@ ValueConstIterator::ValueConstIterator()
 }
 
 
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
 ValueConstIterator::ValueConstIterator( const Value::ObjectValues::iterator &current )
    : ValueIteratorBase( current )
 {
@@ -262,7 +262,7 @@ ValueIterator::ValueIterator()
 }
 
 
-#ifndef JSON_VALUE_USE_INTERNAL_MAP
+#ifndef JSONCPP_VALUE_USE_INTERNAL_MAP
 ValueIterator::ValueIterator( const Value::ObjectValues::iterator &current )
    : ValueIteratorBase( current )
 {

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -3,10 +3,10 @@
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
 
-#if !defined(JSON_IS_AMALGAMATION)
+#if !defined(JSONCPP_IS_AMALGAMATION)
 # include <json/writer.h>
 # include "json_tool.h"
-#endif // if !defined(JSON_IS_AMALGAMATION)
+#endif // if !defined(JSONCPP_IS_AMALGAMATION)
 #include <utility>
 #include <assert.h>
 #include <stdio.h>
@@ -56,7 +56,7 @@ std::string valueToString( LargestUInt value )
    return current;
 }
 
-#if defined(JSON_HAS_INT64)
+#if defined(JSONCPP_HAS_INT64)
 
 std::string valueToString( Int value )
 {
@@ -69,7 +69,7 @@ std::string valueToString( UInt value )
    return valueToString( LargestUInt(value) );
 }
 
-#endif // # if defined(JSON_HAS_INT64)
+#endif // # if defined(JSONCPP_HAS_INT64)
 
 
 std::string valueToString( double value )

--- a/src/test_lib_json/jsontest.cpp
+++ b/src/test_lib_json/jsontest.cpp
@@ -363,19 +363,19 @@ Runner::runTestAt( unsigned int index, TestResult &result ) const
    result.setTestName( test->testName() );
    printf( "Testing %s: ", test->testName() );
    fflush( stdout );
-#if JSON_USE_EXCEPTION
+#if JSONCPP_USE_EXCEPTION
    try 
    {
-#endif // if JSON_USE_EXCEPTION
+#endif // if JSONCPP_USE_EXCEPTION
       test->run( result );
-#if JSON_USE_EXCEPTION
+#if JSONCPP_USE_EXCEPTION
    } 
    catch ( const std::exception &e ) 
    {
       result.addFailure( __FILE__, __LINE__, 
          "Unexpected exception caugth:" ) << e.what();
    }
-#endif // if JSON_USE_EXCEPTION
+#endif // if JSONCPP_USE_EXCEPTION
    delete test;
    const char *status = result.failed() ? "FAILED" 
                                         : "OK";


### PR DESCRIPTION
The nlohmann json library also defines the [JSON_ASSERT macro](https://github.com/nlohmann/json/blob/6cc0eaf88f14493719c440dc5c343ee70aa5551f/single_include/nlohmann/json.hpp#L2544) which may cause compile errors if both are used side-by-side.